### PR TITLE
WIP:ExperimentClass: create write_path if it doesn't exist

### DIFF
--- a/mirp/dicomImport.py
+++ b/mirp/dicomImport.py
@@ -304,7 +304,7 @@ def _find_dicom_image_series(image_folder, allowed_modalities, modality=None, se
     elif frame_of_ref_uid is not None:
 
         if frame_of_ref_uid not in series_FOR_uid:
-            raise ValueError(f"The requested frame of reference UID ({frame_of_ref_uid}) was not found in the DICOM folder. Found: {list(set(series_FOR_uid))}")
+            raise ValueError(f"The requested frame of reference UID ({frame_of_ref_uid}) was not found in the DICOM folder {image_folder}. Found: {list(set(series_FOR_uid))}")
 
     else:
         frame_of_ref_uid = series_FOR_uid[0]

--- a/mirp/experimentClass.py
+++ b/mirp/experimentClass.py
@@ -2,8 +2,9 @@
 # disable_multi_threading()
 
 import numpy as np
-import pandas as pd
 import os
+import pandas as pd
+import sys
 
 from mirp.importSettings import SettingsClass
 from mirp.utilities import expand_grid
@@ -266,7 +267,9 @@ class ExperimentClass:
         import copy
 
         # Configure logger
-        logging.basicConfig(format="%(levelname)s\t: %(processName)s \t %(asctime)s \t %(message)s", level=logging.INFO)
+        logging.basicConfig(
+            format="%(levelname)s\t: %(processName)s \t %(asctime)s \t %(message)s",
+            level=logging.INFO, stream=sys.stdout)
 
         # Initialise empty feature list
         feat_list = []
@@ -474,10 +477,12 @@ class ExperimentClass:
         from mirp.imagePlot import plot_image
 
         # Configure logger
-        logging.basicConfig(format="%(levelname)s\t: %(processName)s \t %(asctime)s \t %(message)s", level=logging.INFO)
+        logging.basicConfig(
+            format="%(levelname)s\t: %(processName)s \t %(asctime)s \t %(message)s",
+            level=logging.INFO, stream=sys.stdout)
 
         # Notifications
-        logging.info("Initialising image and mask processing using %s images for %s.", self.modality + "_" + self.data_str + "_", self.subject)
+        logging.info("\nInitialising image and mask processing using %s images for %s.", self.modality + "_" + self.data_str + "_", self.subject)
 
         # Get iterables from current settings which lead to different image adaptations
         iter_set, n_outer_iter, n_inner_iter = self.get_iterable_parameters(settings=self.settings)
@@ -504,12 +509,12 @@ class ExperimentClass:
             # Log current iteration
             if n_outer_iter * n_inner_iter > 1:
                 if n_inner_iter > 1:
-                    logging.info("Processing image and mask for %s to %s of %s adaptations.", str(ii * n_inner_iter + 1), str((ii + 1) * n_inner_iter),
+                    logging.info("\nProcessing image and mask for %s to %s of %s adaptations.\n", str(ii * n_inner_iter + 1), str((ii + 1) * n_inner_iter),
                                  str(n_outer_iter * n_inner_iter))
                 else:
-                    logging.info("Processing image and mask for %s of %s adaptations.", str(ii + 1), str(n_outer_iter))
+                    logging.info("\nProcessing image and mask for %s of %s adaptations.\n", str(ii + 1), str(n_outer_iter))
             else:
-                logging.info("Starting image and mask processing.")
+                logging.info("\nStarting image and mask processing.\n")
 
             ########################################################################################################
             # Load and pre-process image and roi

--- a/mirp/experimentClass.py
+++ b/mirp/experimentClass.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+import os
 
 from mirp.importSettings import SettingsClass
 from mirp.utilities import expand_grid
@@ -42,6 +43,8 @@ class ExperimentClass:
 
         # Path for writing data
         self.write_path = write_path
+        if not os.path.isdir(self.write_path):
+            os.makedirs(self.write_path)
 
         # Paths to image and segmentation folders
         self.image_folder = image_folder

--- a/mirp/imagePlot.py
+++ b/mirp/imagePlot.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import matplotlib.pyplot as plt
 import numpy as np
 
-from mirp.utilities import check_string
+from mirp.utilities import check_string, makedirs_check
 
 
 def plot_image(img_obj, roi_list=None, slice_id="all", roi_mask=None, file_path=None, file_name="plot", g_range=None):
@@ -103,6 +103,12 @@ def plot_image(img_obj, roi_list=None, slice_id="all", roi_mask=None, file_path=
     else:
         roi_flag = None
 
+    # create directory for the given patient
+    img_descriptor = check_string(img_obj.get_export_descriptor())
+    plot_path = os.path.join(file_path, img_descriptor) if file_path is not None else None
+    if plot_path is not None:
+        makedirs_check(plot_path)
+
     # Plot without roi ################################################
     # If no rois are present, iterate over slices only
     if roi_list is None:
@@ -115,8 +121,8 @@ def plot_image(img_obj, roi_list=None, slice_id="all", roi_mask=None, file_path=
         for curr_slice in slice_id:
 
             # Set file name
-            if file_path is not None:
-                plot_file_name = os.path.join(file_path, check_string(file_name + "_" + img_obj.get_export_descriptor() + "_" + str(curr_slice) + ".png"))
+            if plot_path is not None:
+                plot_file_name = os.path.join(plot_path, check_string(file_name + "_" + str(curr_slice) + ".png"))
             else:
                 plot_file_name = None
 
@@ -134,6 +140,10 @@ def plot_image(img_obj, roi_list=None, slice_id="all", roi_mask=None, file_path=
 
         # Iterate over rois in roi_list
         for curr_roi in roi_list:
+            roi_descriptor = check_string(curr_roi.get_export_descriptor())
+            plot_path_roi = os.path.join(plot_path, roi_descriptor) if plot_path is not None else None
+            if plot_path_roi is not None:
+                makedirs_check(plot_path_roi)
 
             # Find roi center slice
             if slice_id is None:
@@ -150,8 +160,8 @@ def plot_image(img_obj, roi_list=None, slice_id="all", roi_mask=None, file_path=
             for curr_slice in slice_id:
 
                 # Set file name
-                if file_path is not None:
-                    plot_file_name = os.path.join(file_path, check_string(file_name + "_" + img_obj.get_export_descriptor() + curr_roi.get_export_descriptor() + "_" + str(curr_slice) + ".png"))
+                if plot_path_roi is not None:
+                    plot_file_name = os.path.join(plot_path_roi, check_string(file_name + "_" + str(curr_slice) + ".png"))
                 else:
                     plot_file_name = None
 

--- a/mirp/importSettings.py
+++ b/mirp/importSettings.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ElemTree
 
 import numpy as np
 import pandas as pd
+import sys
 
 
 class GeneralSettingsClass:
@@ -372,7 +373,9 @@ def import_data_settings(path, config_settings, compute_features=False, extract_
         return file_found
 
     # Configure logger
-    logging.basicConfig(format="%(levelname)s\t: %(processName)s \t %(asctime)s \t %(message)s", level=logging.INFO)
+    logging.basicConfig(
+        format="%(levelname)s\t: %(processName)s \t %(asctime)s \t %(message)s",
+        level=logging.INFO, stream=sys.stdout)
 
     # Load xml
     tree = ElemTree.parse(path)

--- a/mirp/utilities.py
+++ b/mirp/utilities.py
@@ -105,3 +105,13 @@ def get_spherical_structure(radius, spacing):
     geom_struct = np.sqrt(grid_z + grid_y + grid_x) <= radius
 
     return geom_struct
+
+
+def makedirs_check(path):
+    """
+    Checks if the given path is an existing directory
+    structure, otherwise creates it.
+    """
+
+    if not os.path.isdir(path):
+        os.makedirs(path)


### PR DESCRIPTION
Currently the user has to make sure that the directory structure as provided by the `write_folder` tag in the `data_config.xml` already exists before running the feature extraction. If that is not the case, mirp crashes when trying to save plots.