### PR TITLE
Fix pandas indexing and some deprecation issues

### DIFF
--- a/mirp/featureSets/intensityHistogram.py
+++ b/mirp/featureSets/intensityHistogram.py
@@ -160,12 +160,12 @@ def compute_intensity_histogram_features(df_img, g_range):
     df_feat["ih_max_grad"] = np.max(df_his.grad)
 
     # Maximum histogram gradient grey level
-    df_feat["ih_max_grad_g"] = df_his.g[df_his.grad.idxmax]
+    df_feat["ih_max_grad_g"] = df_his.g[df_his.grad.idxmax()]
 
     # Minimum histogram gradient
     df_feat["ih_min_grad"] = np.min(df_his.grad)
 
     # Minimum histogram gradient grey level
-    df_feat["ih_min_grad_g"] = df_his.g[df_his.grad.idxmin]
+    df_feat["ih_min_grad_g"] = df_his.g[df_his.grad.idxmin()]
 
     return df_feat

--- a/mirp/featureSets/localIntensity.py
+++ b/mirp/featureSets/localIntensity.py
@@ -101,7 +101,7 @@ def compute_local_mean_intensity_direct(img_obj, roi_obj):
 
     # Generate position matrix
     pos_mat = np.array(
-        np.unravel_index(indices=np.arange(0, np.prod(img_obj.size)), dims=img_obj.size),
+        np.unravel_index(indices=np.arange(0, np.prod(img_obj.size)), shape=img_obj.size),
         dtype=np.float32).transpose()
 
     # Iterate over voxels in the roi

--- a/mirp/featureSets/volumeMorphology.py
+++ b/mirp/featureSets/volumeMorphology.py
@@ -487,7 +487,7 @@ def get_minimum_oriented_bounding_box(pos_mat):
         del work_pos, aabb_dims
 
     # Find minimal volume of all rotations and return bounding box dimensions
-    sel_row   = rot_df.loc[rot_df.vol.idxmin, :]
+    sel_row   = rot_df.loc[rot_df.vol.idxmin(), :]
     ombb_dims = np.array([sel_row.aabb_axis_0, sel_row.aabb_axis_1, sel_row.aabb_axis_2])
 
     return ombb_dims

--- a/mirp/featureSets/volumeMorphology.py
+++ b/mirp/featureSets/volumeMorphology.py
@@ -260,13 +260,13 @@ def get_volumetric_morphological_features(img_obj, roi_obj, settings):
 def mesh_voxels(roi_obj):
     """Generate a closed mesh from the morphological mask"""
 
-    from skimage.measure import marching_cubes_lewiner
+    from skimage.measure import marching_cubes
 
     # Get ROI and pad with empty voxels
     morphology_mask = np.pad(roi_obj.roi_morphology.get_voxel_grid(), pad_width=1, mode="constant", constant_values=0.0)
 
     # Use marching cubes to generate a mesh grid for the ROI
-    vertices, faces, norms, values = marching_cubes_lewiner(volume=morphology_mask, level=0.5, spacing=tuple(roi_obj.roi_morphology.spacing))
+    vertices, faces, norms, values = marching_cubes(volume=morphology_mask, level=0.5, spacing=tuple(roi_obj.roi_morphology.spacing))
 
     return vertices, faces, norms
 

--- a/mirp/morphologyUtilities.py
+++ b/mirp/morphologyUtilities.py
@@ -561,7 +561,7 @@ def getPerimeter(roi_slice, spacing):
     roi_dims    = np.shape(roi_slice)
 
     # Create data frame
-    vox_indices = np.unravel_index(indices=np.arange(start=0, stop=roi_slice.size), dims=np.shape(roi_slice))
+    vox_indices = np.unravel_index(indices=np.arange(start=0, stop=roi_slice.size), shape=np.shape(roi_slice))
     df_slice = pd.DataFrame({"index_id": np.arange(start=0, stop=roi_slice.size),
                              "border":   np.ravel(roi_b_slice),
                              "y_ind":    vox_indices[0],

--- a/mirp/roiClass.py
+++ b/mirp/roiClass.py
@@ -769,7 +769,7 @@ class RoiClass:
         # Create table from test object
         img_dims = img_obj.size
         index_id = np.arange(start=0, stop=np.prod(img_dims))
-        coords = np.unravel_index(indices=index_id, dims=img_dims)
+        coords = np.unravel_index(indices=index_id, shape=img_dims)
         df_img = pd.DataFrame({"index_id": index_id,
                                "g":        np.ravel(img_obj.get_voxel_grid()),
                                "x": coords[2],


### PR DESCRIPTION
Main thing is that the `idxmax` and `idxmin` calls within `pd.DataFrame` objects have to be called and are not attributes.

Also the `np.unravel_index` function no longer has a `dims` parameter, that was renamed to `shape` in numpy 1.16.

The used `marching_cubes_lewiner` function is also deprecated and removed in recent `skimage` versions (from 0.19 onward I think), so I changed that as well.