### PR TITLE
Implement tmp_path

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+concurrency = multiprocessing
+parallel = true

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -124,14 +124,10 @@ def run_experiment(image, roi, **kwargs):
     return data
 
 
-def test_xml_configurations():
+def test_xml_configurations(tmp_path):
     # Read the data settings xml file, and update path to image and mask.
     from xml.etree import ElementTree as ElemTree
     from mirp.extract_features_and_images import extract_features
-
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml")):
-        os.remove(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml"))
 
     # Load xml.
     tree = ElemTree.parse(os.path.join(CURRENT_DIR, "data", "configuration_files", "test_config_data.xml"))
@@ -144,12 +140,12 @@ def test_xml_configurations():
         mask.text = str(os.path.join(CURRENT_DIR, "data", "sts_images"))
 
     # Save as temporary xml file.
-    tree.write(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml"))
+    tree.write(tmp_path / "temp_test_config_data.xml")
 
     data = extract_features(
         write_features=False,
         export_features=True,
-        image=os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml"),
+        image=str(tmp_path / "temp_test_config_data.xml"),
         settings=os.path.join(CURRENT_DIR, "data", "configuration_files", "test_config_settings.xml")
     )
 
@@ -161,9 +157,6 @@ def test_xml_configurations():
     assert all(data["image_voxel_size_x"].values == 3.0)
     assert all(data["image_voxel_size_y"].values == 3.0)
     assert all(data["image_voxel_size_z"].values == 3.0)
-
-    # Clean up
-    os.remove(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml"))
 
 
 def test_edge_cases_basic_pipeline():

--- a/test/configuration_test.py
+++ b/test/configuration_test.py
@@ -16,19 +16,16 @@ def _type_converter(type_str: str):
         raise ValueError(f"type could not be linked to an object type: {type_str}")
 
 
-def test_general_settings_configuration():
+def test_general_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.general_parameters import get_general_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     settings_definitions = get_general_settings()
 
@@ -80,23 +77,17 @@ def test_general_settings_configuration():
         assert getattr(settings_keyword.general, class_key) == test_value
         assert isinstance(test_value, value_type)
 
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
 
-
-def test_post_processing_settings_configuration():
+def test_post_processing_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.image_processing_parameters import get_post_processing_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     settings_definitions = get_post_processing_settings()
 
@@ -157,23 +148,17 @@ def test_post_processing_settings_configuration():
             assert getattr(settings_keyword.post_process, class_key) == test_value
             assert isinstance(test_value, value_type)
 
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
 
-
-def test_interpolation_settings_configuration():
+def test_interpolation_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.interpolation_parameters import get_image_interpolation_settings, get_mask_interpolation_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     # All default settings.
     tree = ElemTree.parse(temp_file)
@@ -270,23 +255,17 @@ def test_interpolation_settings_configuration():
             assert getattr(settings_keyword.roi_interpolate, class_key) == test_value
             assert isinstance(test_value, value_type)
 
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
 
-
-def test_perturbation_settings_configuration():
+def test_perturbation_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.perturbation_parameters import get_perturbation_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     settings_definitions = get_perturbation_settings()
 
@@ -347,23 +326,17 @@ def test_perturbation_settings_configuration():
             assert getattr(settings_keyword.perturbation, class_key) == test_value
             assert isinstance(test_value, value_type)
 
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
 
-
-def test_mask_resegmentation_settings_configuration():
+def test_mask_resegmentation_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.resegmentation_parameters import get_mask_resegmentation_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     settings_definitions = get_mask_resegmentation_settings()
 
@@ -424,23 +397,17 @@ def test_mask_resegmentation_settings_configuration():
             assert getattr(settings_keyword.roi_resegment, class_key) == test_value
             assert isinstance(test_value, value_type)
 
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
 
-
-def test_feature_extraction_settings_configuration():
+def test_feature_extraction_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.feature_parameters import get_feature_extraction_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     settings_definitions = get_feature_extraction_settings()
 
@@ -504,23 +471,17 @@ def test_feature_extraction_settings_configuration():
             assert getattr(settings_keyword.feature_extr, class_key) == test_value
             assert isinstance(test_value, value_type)
 
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
 
-
-def test_image_transformation_settings_configuration():
+def test_image_transformation_settings_configuration(tmp_path):
     from xml.etree import ElementTree as ElemTree
     from mirp import get_settings_xml
     from mirp.settings.transformation_parameters import get_image_transformation_settings
     from mirp.settings.import_config_parameters import create_settings_object
     from mirp.settings.generic import SettingsClass
 
-    temp_file = os.path.join(CURRENT_DIR, "data", "configuration_files", "settings.xml")
+    temp_file = tmp_path / "settings.xml"
 
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(temp_file):
-        os.remove(temp_file)
-    get_settings_xml(os.path.join(CURRENT_DIR, "data", "configuration_files"))
+    get_settings_xml(tmp_path)
 
     settings_definitions = get_image_transformation_settings()
 
@@ -597,6 +558,3 @@ def test_image_transformation_settings_configuration():
         else:
             assert getattr(settings_keyword.img_transform, class_key) == test_value
             assert isinstance(test_value, value_type)
-
-    if os.path.exists(temp_file):
-        os.remove(temp_file)

--- a/test/export_image_and_mask_test.py
+++ b/test/export_image_and_mask_test.py
@@ -6,37 +6,28 @@ from mirp.extract_features_and_images import extract_features_and_images
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_basic_ct_feature_extraction():
-    import shutil
-
-    write_dir = os.path.join(CURRENT_DIR, "data", "temp_data")
-    if os.path.exists(write_dir):
-        shutil.rmtree(write_dir)
-
+def test_basic_ct_feature_extraction(tmp_path):
     image = np.zeros((128, 128), dtype=float)
     image[32:64, 32:64] = 1.0
 
     mask = np.zeros((128, 128), dtype=bool)
     mask[48:64, 48:64] = True
 
-    data = extract_features_and_images(
+    extract_features_and_images(
         write_features=True,
         export_features=True,
         write_images=True,
         export_images=False,
-        write_dir=write_dir,
+        write_dir=tmp_path,
         image=image,
         mask=mask,
         base_feature_families="statistics"
     )
 
     # Check that files exist.
-    file_names = [file for file in os.listdir(write_dir) if os.path.isfile(os.path.join(write_dir, file))]
+    file_names = [file for file in os.listdir(tmp_path) if (tmp_path / file).is_file()]
 
     assert len(file_names) == 3
     assert len([file for file in file_names if file.endswith(".csv")]) == 1
     assert len([file for file in file_names if file.endswith(".nii.gz")]) == 2
     assert len([file for file in file_names if "mask" in file]) == 1
-
-    if os.path.exists(write_dir):
-        shutil.rmtree(write_dir)

--- a/test/ibsi_2_feature_test.py
+++ b/test/ibsi_2_feature_test.py
@@ -84,12 +84,8 @@ def _process_experiment(
         configuration_id: str,
         by_slice: bool,
         image_transformation_settings: ImageTransformationSettingsClass,
+        tmp_path: str | os.PathLike,
         base_feature_families: str = "none"):
-
-    # Set testing directory
-    test_dir = os.path.join(CURRENT_DIR, "data", "temp")
-    if not os.path.isdir(test_dir) and WRITE_TEMP_FILES:
-        os.makedirs(test_dir)
 
     # Get default settings.
     general_settings, image_interpolation_settings, feature_computation_parameters, resegmentation_settings, \
@@ -121,10 +117,10 @@ def _process_experiment(
     data = data[0]
 
     if WRITE_TEMP_FILES:
-        file_name = [configuration_id, "perturb", "features.csv"] if PERTURB_IMAGES else [configuration_id, "features.csv"]
+        file_name = "_".join([configuration_id, "perturb", "features.csv"] if PERTURB_IMAGES else [configuration_id, "features.csv"])
 
         data.to_csv(
-            os.path.join(test_dir, "_".join(file_name)),
+            tmp_path / file_name,
             sep=";",
             decimal=".",
             index=False
@@ -133,7 +129,7 @@ def _process_experiment(
     return data
 
 
-def test_ibsi_2_config_none():
+def test_ibsi_2_config_none(tmp_path):
     """
     Compare computed feature values with reference values for configurations 1A and 1B of IBSI 2 phase 2.
     """
@@ -151,6 +147,7 @@ def test_ibsi_2_config_none():
         configuration_id="1.A",
         by_slice=True,
         image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
         base_feature_families="statistics"
     )
 
@@ -186,6 +183,7 @@ def test_ibsi_2_config_none():
         configuration_id="1.B",
         by_slice=False,
         image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
         base_feature_families="statistics"
     )
 
@@ -209,7 +207,7 @@ def test_ibsi_2_config_none():
     assert (within_tolerance(52600, 2800, data["stat_var"]))
 
 
-def test_ibsi_2_config_mean_filter():
+def test_ibsi_2_config_mean_filter(tmp_path):
     """
     Compare computed feature values with reference values for configurations 2A and 2B of IBSI 2 phase 2.
     """
@@ -227,7 +225,8 @@ def test_ibsi_2_config_mean_filter():
     data = _process_experiment(
         configuration_id="2.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path
     )
 
     data.columns = [column_name.replace("mean_d_5_", "") for column_name in data.columns]
@@ -264,7 +263,8 @@ def test_ibsi_2_config_mean_filter():
     data = _process_experiment(
         configuration_id="2.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("mean_d_5_", "") for column_name in data.columns]
@@ -289,7 +289,7 @@ def test_ibsi_2_config_mean_filter():
     assert (within_tolerance(44400, 2300, data["stat_var"]))
 
 
-def test_ibsi_2_config_laplacian_of_gaussian_filter():
+def test_ibsi_2_config_laplacian_of_gaussian_filter(tmp_path):
     """
     Compare computed feature values with reference values for configurations 3A and 3B of IBSI 2 phase 2.
     """
@@ -308,7 +308,8 @@ def test_ibsi_2_config_laplacian_of_gaussian_filter():
     data = _process_experiment(
         configuration_id="3.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("log_s_1.5_", "") for column_name in data.columns]
@@ -346,7 +347,8 @@ def test_ibsi_2_config_laplacian_of_gaussian_filter():
     data = _process_experiment(
         configuration_id="3.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("log_s_1.5_", "") for column_name in data.columns]
@@ -371,7 +373,7 @@ def test_ibsi_2_config_laplacian_of_gaussian_filter():
     assert (within_tolerance(720, 33, data["stat_var"]))
 
 
-def test_ibsi_2_config_laws_filter():
+def test_ibsi_2_config_laws_filter(tmp_path):
     """
     Compare computed feature values with reference values for configurations 4A and 4B of IBSI 2 phase 2.
     """
@@ -393,7 +395,8 @@ def test_ibsi_2_config_laws_filter():
     data = _process_experiment(
         configuration_id="4.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("laws_l5e5_energy_delta_7_invar_", "") for column_name in data.columns]
@@ -434,7 +437,8 @@ def test_ibsi_2_config_laws_filter():
     data = _process_experiment(
         configuration_id="4.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("laws_l5e5e5_energy_delta_7_invar_", "") for column_name in data.columns]
@@ -459,7 +463,7 @@ def test_ibsi_2_config_laws_filter():
     assert (within_tolerance(11100, 300, data["stat_var"]))
 
 
-def test_ibsi_2_config_gabor_filter():
+def test_ibsi_2_config_gabor_filter(tmp_path):
     """
     Compare computed feature values with reference values for configurations 5A and 5B of IBSI 2 phase 2.
     """
@@ -484,7 +488,8 @@ def test_ibsi_2_config_gabor_filter():
     data = _process_experiment(
         configuration_id="5.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("gabor_s_5.0_g_1.5_l_2.0_2D_", "") for column_name in data.columns]
@@ -528,7 +533,8 @@ def test_ibsi_2_config_gabor_filter():
     data = _process_experiment(
         configuration_id="5.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("gabor_s_5.0_g_1.5_l_2.0_3D_invar_", "") for column_name in data.columns]
@@ -553,7 +559,7 @@ def test_ibsi_2_config_gabor_filter():
     assert (within_tolerance(231, 2, data["stat_var"]))
 
 
-def test_ibsi_2_config_daubechies_filter():
+def test_ibsi_2_config_daubechies_filter(tmp_path):
     """
     Compare computed feature values with reference values for configurations 6A, 6B, 7A and 7B of IBSI 2 phase 2.
     """
@@ -575,7 +581,8 @@ def test_ibsi_2_config_daubechies_filter():
     data = _process_experiment(
         configuration_id="6.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_db3_lh_level_1_invar_", "") for column_name in data.columns]
@@ -616,7 +623,8 @@ def test_ibsi_2_config_daubechies_filter():
     data = _process_experiment(
         configuration_id="6.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_db3_llh_level_1_invar_", "") for column_name in data.columns]
@@ -657,7 +665,8 @@ def test_ibsi_2_config_daubechies_filter():
     data = _process_experiment(
         configuration_id="7.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_db3_hh_level_2_invar_", "") for column_name in data.columns]
@@ -698,7 +707,8 @@ def test_ibsi_2_config_daubechies_filter():
     data = _process_experiment(
         configuration_id="7.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_db3_hhh_level_2_invar_", "") for column_name in data.columns]
@@ -723,7 +733,7 @@ def test_ibsi_2_config_daubechies_filter():
     assert (within_tolerance(422, 11, data["stat_var"]))
 
 
-def test_ibsi_2_config_simoncelli_filter():
+def test_ibsi_2_config_simoncelli_filter(tmp_path):
     """
     Compare computed feature values with reference values for configurations 8A, 8B, 9A and 9B of IBSI 2 phase 2.
     """
@@ -742,7 +752,8 @@ def test_ibsi_2_config_simoncelli_filter():
     data = _process_experiment(
         configuration_id="8.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_simoncelli_level_1_", "") for column_name in data.columns]
@@ -780,7 +791,8 @@ def test_ibsi_2_config_simoncelli_filter():
     data = _process_experiment(
         configuration_id="8.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_simoncelli_level_1_", "") for column_name in data.columns]
@@ -817,7 +829,8 @@ def test_ibsi_2_config_simoncelli_filter():
     data = _process_experiment(
         configuration_id="9.A",
         by_slice=True,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_simoncelli_level_2_", "") for column_name in data.columns]
@@ -855,7 +868,8 @@ def test_ibsi_2_config_simoncelli_filter():
     data = _process_experiment(
         configuration_id="9.B",
         by_slice=False,
-        image_transformation_settings=image_transformation_settings
+        image_transformation_settings=image_transformation_settings,
+        tmp_path=tmp_path,
     )
 
     data.columns = [column_name.replace("wavelet_simoncelli_level_2_", "") for column_name in data.columns]

--- a/test/import_image_and_mask_test.py
+++ b/test/import_image_and_mask_test.py
@@ -588,7 +588,7 @@ def test_failure_multiple_image_and_mask_import():
     # DICOM stack and _masks for all samples, but with incorrect instructions.
     # No matching file type.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             image_file_type="nifti",
             image_sub_folder=os.path.join("CT", "dicom", "image"),
@@ -599,7 +599,7 @@ def test_failure_multiple_image_and_mask_import():
     # DICOM stack and _masks for all samples, but with incorrect instructions.
     # No matching image modality.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             image_modality="pet",
             image_sub_folder=os.path.join("CT", "dicom", "image"),
@@ -610,7 +610,7 @@ def test_failure_multiple_image_and_mask_import():
     # DICOM stack and _masks for all samples, but with incorrect instructions.
     # No matching mask modality.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             mask_modality="seg",
             image_sub_folder=os.path.join("CT", "dicom", "image"),
@@ -621,7 +621,7 @@ def test_failure_multiple_image_and_mask_import():
     # DICOM stack and _masks for all samples, but with incorrect instructions.
     # Wrong image_name.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             image_name="false_image",
             image_sub_folder=os.path.join("CT", "dicom", "image"),
@@ -633,7 +633,7 @@ def test_failure_multiple_image_and_mask_import():
     # DICOM stack and _masks for all samples, but with incorrect instructions.
     # Wrong mask_name.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             mask_name="false_mask",
             image_sub_folder=os.path.join("CT", "dicom", "image"),
@@ -645,7 +645,7 @@ def test_failure_multiple_image_and_mask_import():
     # Read Nifti image and _masks for all samples, but with incorrect instructions.
     # No matching sample name.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             image_sub_folder=os.path.join("CT", "nifti", "image"),
             sample_name="false_sample_name",
@@ -656,7 +656,7 @@ def test_failure_multiple_image_and_mask_import():
     # Read Nifti image and _masks for all samples, but with incorrect instructions.
     # Wrong image_name.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             image_sub_folder=os.path.join("CT", "nifti", "image"),
             image_name="false_image",
@@ -668,7 +668,7 @@ def test_failure_multiple_image_and_mask_import():
     # Read Nifti image and _masks for all samples, but with incorrect instructions.
     # Wrong mask_name.
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=os.path.join(CURRENT_DIR, "data", "sts_images"),
             image_sub_folder=os.path.join("CT", "nifti", "image"),
             mask_name="false_mask",
@@ -678,19 +678,18 @@ def test_failure_multiple_image_and_mask_import():
     assert "that contain the name pattern (false_mask)" in str(exception_info.value)
 
 
-def test_failure_multiple_image_and_mask_import_data_xml():
+def test_failure_multiple_image_and_mask_import_data_xml(tmp_path):
     # Read the data settings xml file, and update path to image and mask.
     from xml.etree import ElementTree as ElemTree
     from mirp import get_data_xml
 
-    target_dir = os.path.join(CURRENT_DIR, "data", "temp")
-    target_file = os.path.join(target_dir, "data.xml")
+    target_file = str(tmp_path / "data.xml")
 
     # Start with a clean slate.
     if os.path.exists(target_file):
         os.remove(target_file)
 
-    get_data_xml(target_dir=target_dir)
+    get_data_xml(target_dir=tmp_path)
 
     # Load xml.
     tree = ElemTree.parse(target_file)
@@ -714,7 +713,7 @@ def test_failure_multiple_image_and_mask_import_data_xml():
     false_file_type_tree.write(target_file)
 
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=target_file
         )
     assert "did not contain any supported image files" in str(exception_info.value)
@@ -727,7 +726,7 @@ def test_failure_multiple_image_and_mask_import_data_xml():
     false_image_modality_tree.write(target_file)
 
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=target_file
         )
     assert "No images were found" in str(exception_info.value)
@@ -740,7 +739,7 @@ def test_failure_multiple_image_and_mask_import_data_xml():
     false_mask_modality_tree.write(target_file)
 
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=target_file
         )
     assert "No masks were found" in str(exception_info.value)
@@ -753,7 +752,7 @@ def test_failure_multiple_image_and_mask_import_data_xml():
     false_image_name_tree.write(target_file)
 
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=target_file
         )
     assert "not contain any supported image files" in str(exception_info.value)
@@ -766,7 +765,7 @@ def test_failure_multiple_image_and_mask_import_data_xml():
         element.text = "false_mask"
     false_mask_name_tree.write(target_file)
     with pytest.raises(ValueError) as exception_info:
-        image_list = import_image_and_mask(
+        import_image_and_mask(
             image=target_file
         )
     assert "not contain any supported mask files" in str(exception_info.value)

--- a/test/perturbation_test.py
+++ b/test/perturbation_test.py
@@ -476,15 +476,7 @@ def run_experiment(perturbation_settings, by_slice=False):
         perturbation_settings=perturbation_settings
     )
 
-    # Set testing directory
-    if WRITE_TEMP_FILES:
-        write_path = os.path.join(CURRENT_DIR, "data", "temp")
-
-        # Create directory, if necessary.
-        if not os.path.isdir(write_path):
-            os.makedirs(write_path)
-    else:
-        write_path = None
+    # TODO: Is support for writing a tempdir needed? `write_dir` wasn't used...
 
     data = extract_features_and_images(
         write_features=False,

--- a/test/read_image_and_mask_test.py
+++ b/test/read_image_and_mask_test.py
@@ -379,13 +379,9 @@ def test_read_generic_image_and_mask_modality_specific():
     assert roi_list[0].roi_name == "region_1"
 
 
-def test_read_dicom_image_and_mask_data_xml():
+def test_read_dicom_image_and_mask_data_xml(tmp_path):
     # Read the data settings xml file, and update path to image and mask.
     from xml.etree import ElementTree as ElemTree
-
-    # Remove temporary data xml file if it exists.
-    if os.path.exists(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml")):
-        os.remove(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml"))
 
     # Load xml.
     tree = ElemTree.parse(os.path.join(CURRENT_DIR, "data", "configuration_files", "test_config_data.xml"))
@@ -398,10 +394,10 @@ def test_read_dicom_image_and_mask_data_xml():
         mask.text = str(os.path.join(CURRENT_DIR, "data", "sts_images"))
 
     # Save as temporary xml file.
-    tree.write(os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml"))
+    tree.write(tmp_path / "temp_test_config_data.xml")
 
     image_list = import_image_and_mask(
-        image=os.path.join(CURRENT_DIR, "data", "configuration_files", "temp_test_config_data.xml")
+        image=str(tmp_path / "temp_test_config_data.xml")
     )
 
     image, roi_list = read_image_and_masks(image=image_list[0])

--- a/test/xml_file_copy_test.py
+++ b/test/xml_file_copy_test.py
@@ -4,15 +4,14 @@ from mirp.utilities.config_utilities import get_settings_xml, get_data_xml
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_copy_settings_xml():
-    target_dir = os.path.join(CURRENT_DIR, "data", "temp")
-    target_file = os.path.join(target_dir, "settings.xml")
+def test_copy_settings_xml(tmp_path):
+    target_file = tmp_path / "settings.xml"
 
     # Start with a clean slate.
     if os.path.exists(target_file):
         os.remove(target_file)
 
-    get_settings_xml(target_dir=target_dir)
+    get_settings_xml(target_dir=tmp_path)
 
     assert os.path.exists(target_file)
 
@@ -20,15 +19,14 @@ def test_copy_settings_xml():
     os.remove(target_file)
 
 
-def test_copy_data_xml():
-    target_dir = os.path.join(CURRENT_DIR, "data", "temp")
-    target_file = os.path.join(target_dir, "data.xml")
+def test_copy_data_xml(tmp_path):
+    target_file = tmp_path / "data.xml"
 
     # Start with a clean slate.
     if os.path.exists(target_file):
         os.remove(target_file)
 
-    get_data_xml(target_dir=target_dir)
+    get_data_xml(target_dir=tmp_path)
 
     assert os.path.exists(target_file)
 


### PR DESCRIPTION
Hi @alexzwanenburg,

I was just trying to run through the your test suite using `pytest-xdist` to accelerate the tests by distributing them over multiple processes. I noticed that you were manually creating and trying to handle cleanup of temporary test directories. This doesn't work well with multiprocessing, since some tests were using the same manually-created test dirs and running into `PermissionErrors` when trying to delete temp files that were being accessed by another process.

PyTest includes a wonderful temporary directory feature when setup and cleanup are neatly handled in the background. A big plus is that they play nicely with `pydist-xdist` - no `PermissionError`s.

I've taken the liberty of implementing PyTest's `tmp_path` into your test suite, replacing the manual system.

If you do adopt the changes, I'd recommend merging this before merging #70 and adapting #70 to these changes along with the changes I proposed in my PR review.

Note that using `pytest-xdist` with `n=14` brought the total test suite runtime down from 20:12 to 03:35!

To use it yourself, all you need to do is run:
```shell
pip install pytest-xdist
pytest -n <numprocesses>....<other pytest options> (e.g. pytest -n 14 -v --color=yes)
```